### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,18 @@
   "description": "Processes PHP files (e.g. PHP templates) to static files.",
   "version": "0.1.1",
   "homepage": "https://github.com/paulgessinger/grunt-phptpl",
-  "authors": [{
-    "name": "Paul Gessinger",
-    "email": "hello@paulgessinger.com",
-    "url": "http://paulgessinger.com"
-  }, {
-    "name": "Alberto Bottarini",
-    "email": "alberto.bottarini@gmail.com",
-    "url": "http://albertobottarini.com"
-  }],
+  "authors": [
+    {
+      "name": "Paul Gessinger",
+      "email": "hello@paulgessinger.com",
+      "url": "http://paulgessinger.com"
+    },
+    {
+      "name": "Alberto Bottarini",
+      "email": "alberto.bottarini@gmail.com",
+      "url": "http://albertobottarini.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:paulgessinger/grunt-phptpl.git"
@@ -39,7 +42,7 @@
     "grunt": "~0.4.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
